### PR TITLE
Use integer type for screenDpi

### DIFF
--- a/lib/src/base.dart
+++ b/lib/src/base.dart
@@ -662,7 +662,7 @@ class Device {
   final double screenDensity;
 
   /// A decimal value reflecting the DPI (dots-per-inch) density.
-  final String screenDpi;
+  final int screenDpi;
 
   /// Whether the device was online or not.
   final bool online;


### PR DESCRIPTION
The sentry API expect the value of screenDpi to be an unsigned integer and not a string.

![afbeelding](https://user-images.githubusercontent.com/7236283/84369280-e6197300-abd6-11ea-8282-1ef2fbad89fa.png)
